### PR TITLE
Add BabiaXR into data-viz doc

### DIFF
--- a/en/pages/data-vis.md
+++ b/en/pages/data-vis.md
@@ -1,4 +1,7 @@
 # Libraries for Graphing
+## aframe-babia-components (BabiaXR)
+[source](https://gitlab.com/babiaxr/aframe-babia-components)
+Maintained. Data visualization/management components.
 ## a-framedc
 [original source](https://github.com/fran-aguilar/a-framedc)
 [fork showing working demos](https://github.com/kylebakerio/a-framedc)


### PR DESCRIPTION
This PRs adds BabiaXR into the data-viz doc.

BabiaXR is a set of components for retrieving, managing, and visualizing data.

Thank you for creating the wiki!